### PR TITLE
Fix Crash while game launching

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -60,5 +60,5 @@ side = "BOTH"
 modId = "epicfight"
 mandatory = true
 versionRange = "[16.5.9, 17)"
-ordering = "NONE"
+ordering = "BEFORE"
 side = "BOTH"


### PR DESCRIPTION
Fix Crash cause by:    java.lang.NoClassDefFoundError: yesman/epicfight/{class_path}

Other versions as same.

Crash reason:
  Your mod's classes loaded earlier than the EFM.